### PR TITLE
Decide proguard rules

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -9,3 +9,4 @@ ironoxide-android/src/androidTest/resources/*.json
 ironoxide-android/.project
 ironoxide-android/.classpath
 ironoxide-android/gradle.properties
+local.properties

--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -13,15 +13,13 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles 'consumer-rules.pro'
         ndk {
             abiFilters 'x86', 'arm64-v8a', 'x86_64'
         }
-
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
It looks like it won't make a big difference, so we can just stick with the defaults. The `.aar` will be ~1% smaller with minify.
We haven't defined any consumer rules, so we don't need to include that.