### PR TITLE
Remove dependency on fixed cross version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,10 +124,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Install Cross
-        run: cargo install cross --version 0.1.16
       - name: Build
         run: |
+          cargo install cross
           cross build --target ${{ matrix.arch }} -p ironoxide-android
           cp -r target/${{ matrix.arch }}/debug/build/ironoxide-android*/out/java android/ironoxide-android/src/main/
           mkdir -p android/ironoxide-android/src/main/jniLibs/${{ matrix.folder-name }}/

--- a/.github/workflows/release2.yaml
+++ b/.github/workflows/release2.yaml
@@ -205,11 +205,10 @@ jobs:
         with:
           java-version: 8
       - run: sudo apt-get install -y clang
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cross --version 0.1.16
-      - run: ./build.sh
+      - name: Install cross
+        run: cargo install cross
+      - name: Run build script
+        run: ./build.sh
         working-directory: android
       - name: Upload release artifact for android
         uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -95,9 +95,8 @@ To make calls, you must create a project and segment in the IronCore Admin Conso
 
 ### Prerequisites
 
-- [Rust toolchain](https://www.rust-lang.org/tools/install) installed
+- [Rust toolchain](https://www.rust-lang.org/tools/install) installed.
 - [cross](https://github.com/rust-embedded/cross) installed.
-  - We currently only support `cross` v0.1.16. This can be installed with `cargo install cross --version 0.1.16`
 - Android SDK 29. You can get the command line SDK [here](https://developer.android.com/studio) (scroll down to "Command line tools only") and then use `sdkmanager` (found in tools/bin) to install additional prerequisites:
 
   ```bash


### PR DESCRIPTION
Now that we don't have a dependency on `openssl`, we can use the latest version of cross.