### PR TITLE
set-versions.sh: Git add ironoxide.pc.in, and add a check for this.

### DIFF
--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -39,6 +39,7 @@ if [ -z "${JAVAONLY}" ] ; then
     done
 
     sed -i"${VERIFY}" -e 's/^Version: .*$/Version: '"${VERS}"'/' cpp/ironoxide.pc.in
+    EDITEDFILES="${EDITEDFILES} cpp/ironoxide.pc.in"
 fi
 
 sed -i"${VERIFY}" -e 's/^VERSION_NAME=.*/VERSION_NAME='"${VERS}"'/' android/gradle.properties
@@ -69,3 +70,10 @@ for FILE in ${EDITEDFILES} ; do
         git add "${FILE}"
     fi
 done
+
+# Look for files that have been changed, but that we haven't told git about.
+echo "Checking for modified but untracked files:"
+if git status -s | grep -Ev '^M ' ; then
+    echo "This probably means $0 modified a file but forgot to 'git add' it."
+    # exit 1
+fi

--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -75,5 +75,5 @@ done
 echo "Checking for modified but untracked files:"
 if git status -s | grep -Ev '^M ' ; then
     echo "This probably means $0 modified a file but forgot to 'git add' it."
-    # exit 1
+    exit 1
 fi


### PR DESCRIPTION
In my previous PR, I added logic to maintain `ironoxide.pc.in`, but I forgot to add it to git.

This commit fixes that, and it also adds a check to look for files that have been forgotten like this.