### PR TITLE
Release fixes

### DIFF
--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -5,7 +5,6 @@
 # If called with -n, don't actually change any files; just verify.
 
 set -e
-set -x
 
 # Parse args
 case "$1" in

--- a/.github/workflows/release2.yaml
+++ b/.github/workflows/release2.yaml
@@ -170,7 +170,9 @@ jobs:
           asset_content_type: application/pgp-signature
 
       - name: Increment to next -SNAPSHOT version for Java.
-        run: .github/set-versions.sh -j ${{ steps.version.outputs.next }}-SNAPSHOT
+        run: |
+          rm -rf release
+          .github/set-versions.sh -j ${{ steps.version.outputs.next }}-SNAPSHOT
       - run: git commit -m "Set next -SNAPSHOT version for Java."
       - run: git push
 

--- a/android/build.sh
+++ b/android/build.sh
@@ -1,3 +1,8 @@
+#!/bin/sh
+
+# Builds the android release. Run from this directory.
+
+set -e
 
 rm -rf ironoxide-android/src/main/java
 rm -rf ironoxide-android/src/main/jniLibs/*

--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -103,9 +103,11 @@ uploadArchives {
     }
 }
 
+// Only sign artifacts if we can upload them.
+tasks.withType(Sign) {
+    onlyIf { NEXUS_USERNAME != "" }
+}
 signing {
-    // Only sign artifacts if we can upload them.
-    required { NEXUS_USERNAME != "" }
     sign configurations.archives
 }
 

--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -37,7 +37,7 @@ uploadArchives {
             pom.artifactId = 'ironoxide-android'
             pom.version = VERSION_NAME
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+            repository(url: "https://oss.sonatype.org/content/repositories/releases/") {
                 authentication(userName: NEXUS_USERNAME,
                                password: NEXUS_PASSWORD)
             }


### PR DESCRIPTION
This fixes several problems with the release process:

- The safety check in `set-versions.sh` was triggering on the `release` directory and failing the build at the last minute.
- The android gradle build was trying to read the signing key, even if it wasn't planning on signing anything.
- The above error was being ignored by `build.sh`.
- The android builds were being uploaded to sonatype staging, not releases.