### PR TITLE
Add Jwt and JwtClaims types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -78,9 +78,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "e223af0dc48c96d4f8342ec01a4974f139df863896b316681efd36742f22cc67"
 
 [[package]]
 name = "base64-serde"
@@ -88,7 +88,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15073133af501014ff0b44d047b0ee2bf0a8c52fa2d13c9624738756638b8505"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.2",
  "serde",
 ]
 
@@ -445,7 +445,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -690,11 +690,10 @@ dependencies = [
 [[package]]
 name = "ironoxide"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304f85dbbbff1affbe2ce617e454185c23dd58c376872e4daebb45959c2abad0"
+source = "git+https://github.com/IronCoreLabs/ironoxide#19934d81d5d50583eb5de6b45233153847f49cc3"
 dependencies = [
  "async-trait",
- "base64 0.12.1",
+ "base64 0.12.2",
  "base64-serde",
  "bytes",
  "chrono",
@@ -703,6 +702,7 @@ dependencies = [
  "hex 0.4.2",
  "ironcore-search-helpers",
  "itertools 0.9.0",
+ "jsonwebtoken",
  "lazy_static",
  "log",
  "percent-encoding",
@@ -809,6 +809,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "7.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f325ae57ddcf609f02d891486ce740f5bbd0cc3e93f9bffaacdf6594b21404"
+dependencies = [
+ "base64 0.12.2",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -936,19 +950,30 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "5.1.1"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.42"
+name = "num-bigint"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -956,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
@@ -992,6 +1017,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+dependencies = [
+ "base64 0.12.2",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,22 +1045,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -1053,9 +1089,9 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afe1bd463b9e9ed51d0e0f0b50b6b146aec855c56fd182bb242388710a9b6de"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -1236,7 +1272,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1297,7 +1333,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "strum",
- "syn 1.0.30",
+ "syn 1.0.31",
  "which",
 ]
 
@@ -1338,29 +1374,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
@@ -1396,6 +1432,17 @@ name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
+name = "simple_asn1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b25ecba7165254f0c97d6c22a64b1122a03634b18d20a34daf21e18f892e618"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
+]
 
 [[package]]
 name = "slab"
@@ -1457,7 +1504,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -1479,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1718,7 +1765,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "wasm-bindgen-shared",
 ]
 
@@ -1752,7 +1799,7 @@ checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,8 +689,9 @@ dependencies = [
 
 [[package]]
 name = "ironoxide"
-version = "0.22.0"
-source = "git+https://github.com/IronCoreLabs/ironoxide#19934d81d5d50583eb5de6b45233153847f49cc3"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3c02814c7402333edfbd029f9c193d6c685f05924fc4015205107bae30c04d"
 dependencies = [
  "async-trait",
  "base64 0.12.2",

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.9.0"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", features = ["blocking", "beta", "tls-rustls"], default-features = false }
+ironoxide = { version = "~0.23", features = ["blocking", "beta", "tls-rustls"], default-features = false }
 chrono = "0.4"
 serde_json = "~1.0"
 jni-sys = "0.3.0"

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.9.0"
-ironoxide = { version = "0.22.0", features = ["blocking", "beta", "tls-rustls"], default-features = false }
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", features = ["blocking", "beta", "tls-rustls"], default-features = false }
 chrono = "0.4"
 serde_json = "~1.0"
 jni-sys = "0.3.0"

--- a/common/lib.rs
+++ b/common/lib.rs
@@ -17,7 +17,7 @@ pub fn hash<T: Hash>(t: &T) -> i32 {
     s.finish() as i32
 }
 
-pub fn eq<T: Eq>(t: &T, other: &T) -> bool {
+pub fn eq<T: PartialEq>(t: &T, other: &T) -> bool {
     t.eq(other)
 }
 
@@ -886,12 +886,50 @@ mod duration {
     }
 }
 
+mod jwt_claims {
+    use super::*;
+    pub fn sub(j: &JwtClaims) -> String {
+        j.sub.clone()
+    }
+    pub fn pid(j: &JwtClaims) -> usize {
+        j.pid
+    }
+    pub fn sid(j: &JwtClaims) -> String {
+        j.sid.clone()
+    }
+    pub fn kid(j: &JwtClaims) -> usize {
+        j.kid
+    }
+    pub fn iat(j: &JwtClaims) -> u64 {
+        j.iat
+    }
+    pub fn exp(j: &JwtClaims) -> u64 {
+        j.exp
+    }
+}
+
+mod jwt {
+    use super::*;
+    pub fn validate(j: &str) -> Result<Jwt, String> {
+        Ok(Jwt::new(j)?)
+    }
+    pub fn jwt(j: &Jwt) -> String {
+        j.jwt().to_string()
+    }
+    pub fn claims(j: &Jwt) -> JwtClaims {
+        j.claims().clone()
+    }
+    pub fn algorithm(j: &Jwt) -> String {
+        format!("{:?}", j.header().alg).to_string()
+    }
+}
+
 //Java SDK wrapper functions for doing unnatural things with the JNI.
-fn user_verify(jwt: &str, timeout: Option<&Duration>) -> Result<Option<UserResult>, String> {
+fn user_verify(jwt: &Jwt, timeout: Option<&Duration>) -> Result<Option<UserResult>, String> {
     Ok(IronOxide::user_verify(jwt, timeout.copied())?)
 }
 fn user_create(
-    jwt: &str,
+    jwt: &Jwt,
     password: &str,
     opts: &UserCreateOpts,
     timeout: Option<&Duration>,
@@ -924,7 +962,7 @@ fn initialize_and_rotate(
     )
 }
 fn generate_new_device(
-    jwt: &str,
+    jwt: &Jwt,
     password: &str,
     opts: &DeviceCreateOpts,
     timeout: Option<&Duration>,

--- a/common/lib.rs.in
+++ b/common/lib.rs.in
@@ -129,6 +129,7 @@ class DeviceId {
 });
 
 foreigner_class!(
+/// Claims required to form a valid `Jwt`.
 class JwtClaims{
     self_type JwtClaims;
     private constructor = empty;
@@ -148,6 +149,10 @@ class JwtClaims{
 });
 
 foreigner_class!(
+/// IronCore JWT.
+///
+/// Must be either ES256 or RS256 and have a payload similar to `JwtClaims`, but could be
+/// generated from an external source.
 class Jwt {
     self_type Jwt;
     private constructor = empty;

--- a/common/lib.rs.in
+++ b/common/lib.rs.in
@@ -129,6 +129,39 @@ class DeviceId {
 });
 
 foreigner_class!(
+class JwtClaims{
+    self_type JwtClaims;
+    private constructor = empty;
+    /// Unique user ID
+    method jwt_claims::sub(&self) -> String; alias getSub;
+    /// Project ID
+    method jwt_claims::pid(&self) -> usize; alias getPid;
+    /// Segment ID
+    method jwt_claims::sid(&self) -> String; alias getSid;
+    /// Service key ID
+    method jwt_claims::kid(&self) -> usize; alias getKid;
+    /// Issued time (seconds)
+    method jwt_claims::iat(&self) -> u64; alias getIat;
+    /// Expiration time (seconds)
+    method jwt_claims::exp(&self) -> u64; alias getExp;
+    pre_build_generate_equals_and_hashcode JwtClaims;
+});
+
+foreigner_class!(
+class Jwt {
+    self_type Jwt;
+    private constructor = empty;
+    static_method jwt::validate(jwt: &str) -> Result<Jwt, String>;
+    /// Raw JWT string
+    method jwt::jwt(&self) -> String; alias getJwt;
+    /// Payload of the JWT
+    method jwt::claims(&self) -> JwtClaims; alias getClaims;
+    /// Algorithm used by the JWT
+    method jwt::algorithm(&self) -> String; alias getAlgorithm;
+    pre_build_generate_equals_and_hashcode Jwt;
+});
+
+foreigner_class!(
 class UserUpdatePrivateKeyResult {
     self_type UserUpdatePrivateKeyResult;
     private constructor = empty;
@@ -769,7 +802,7 @@ class IronOxide {
     /// @param jwt      valid IronCore JWT
     /// @param timeout  timeout for this operation or `null` for no timeout
     /// @return option of whether the user's account record exists in the IronCore system or not. Error if the request couldn't be made.
-    static_method user_verify(jwt:&str, timeout: Option<&Duration>) -> Result<Option<UserResult>, String>; alias userVerify;
+    static_method user_verify(jwt:&Jwt, timeout: Option<&Duration>) -> Result<Option<UserResult>, String>; alias userVerify;
     /// Create a new user within the IronCore system.
     ///
     /// @param jwt       valid IronCore or Auth0 JWT
@@ -778,7 +811,7 @@ class IronOxide {
     /// @param timeout   timeout for this operation or `null` for no timeout
     /// @return see {@link UserCreateResult}. For most use cases, the public key can be discarded as IronCore escrows your user's keys.
     ///         The escrowed keys are unlocked by the provided password.
-    static_method user_create(jwt:&str, password:&str, options:&UserCreateOpts, timeout: Option<&Duration>) -> Result<UserCreateResult, String>; alias userCreate;
+    static_method user_create(jwt:&Jwt, password:&str, options:&UserCreateOpts, timeout: Option<&Duration>) -> Result<UserCreateResult, String>; alias userCreate;
     /// Initialize IronOxide with a device. Verifies that the provided user/segment exists and the provided device
     /// keys are valid and exist for the provided account.
     ///
@@ -810,7 +843,7 @@ class IronOxide {
     /// @param deviceCreateOptions  optional values, like device name
     /// @param timeout              timeout for this operation or `null` for no timeout
     /// @return details about the newly created device
-    static_method generate_new_device(jwt:&str, password:&str, deviceCreateOptions: &DeviceCreateOpts, timeout: Option<&Duration>) -> Result<DeviceAddResult, String>; alias generateNewDevice;
+    static_method generate_new_device(jwt:&Jwt, password:&str, deviceCreateOptions: &DeviceCreateOpts, timeout: Option<&Duration>) -> Result<DeviceAddResult, String>; alias generateNewDevice;
     /// Get all the devices for the current user
     ///
     /// @return all devices for the current user, sorted by the device id

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 log = "0.4"
 itertools = "0.9.0"
-ironoxide = { version = "0.22.0", features = ["blocking", "beta", "tls-rustls"], default-features = false }
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", features = ["blocking", "beta", "tls-rustls"], default-features = false }
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/cpp/Cargo.toml
+++ b/cpp/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 log = "0.4"
 itertools = "0.9.0"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", features = ["blocking", "beta", "tls-rustls"], default-features = false }
+ironoxide = { version = "~0.23", features = ["blocking", "beta", "tls-rustls"], default-features = false }
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.9.0"
-ironoxide = { version = "0.22.0", features = ["blocking", "beta", "tls-rustls"], default-features = false }
+ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", features = ["blocking", "beta", "tls-rustls"], default-features = false }
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 itertools = "0.9.0"
-ironoxide = { git = "https://github.com/IronCoreLabs/ironoxide", features = ["blocking", "beta", "tls-rustls"], default-features = false }
+ironoxide = { version = "~0.23", features = ["blocking", "beta", "tls-rustls"], default-features = false }
 chrono = "0.4"
 serde_json = "~1.0"
 

--- a/java/tests/src/test/scala/ironoxide/UserTests.scala
+++ b/java/tests/src/test/scala/ironoxide/UserTests.scala
@@ -4,14 +4,26 @@ import scala.util.Try
 import com.ironcorelabs.sdk._
 
 class UserTests extends TestSuite {
-  "User Create" should {
+  "Jwt" should {
     "return error for invalid jwt" in {
-      val badResponseTry = Try(IronOxide.userCreate("foo", testUsersPassword, new UserCreateOpts, null)).toEither
-      badResponseTry.leftValue.getMessage should include("must be valid ascii and be formatted correctly")
+      val badJwt = Try(Jwt.validate("foo")).toEither
+      badJwt.isLeft shouldBe true
     }
+    "accept valid jwt" in {
+      val jwt = Try(
+        Jwt.validate(
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJhYmNBQkMwMTJfLiQjfEAvOjs9KyctZDEyMjZkMWItNGMzOS00OWRhLTkzM2MtNjQyZTIzYWMxOTQ1IiwicGlkIjo0MzgsInNpZCI6Imlyb25veGlkZS1kZXYxIiwia2lkIjo1OTMsImlhdCI6MTU5MTkwMTc0MCwiZXhwIjoxNTkxOTAxODYwfQ.wgs_tnh89SlKnIkoQHdlC0REjkxTl1P8qtDSQwWTFKwo8KQKXUQdpp4BfwqUqLcxA0BW6_XfVRlqMX5zcvCc6w"
+        )
+      ).toEither.value
+      jwt.getAlgorithm shouldBe "ES256"
+    }
+  }
+
+  "User Create" should {
     "return error for outdated jwt" in {
-      val jwt =
+      val jwtString =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTA3NzE4MjMsImlhdCI6MTU1MDc3MTcwMywia2lkIjo1NTEsInBpZCI6MTAxMiwic2lkIjoidGVzdC1zZWdtZW50Iiwic3ViIjoiYTAzYjhlNTYtMTVkMi00Y2Y3LTk0MWYtYzYwMWU1NzUxNjNiIn0.vlqt0da5ltA2dYEK9i_pfRxPd3K2uexnkbAbzmbjW65XNcWlBOIbcdmmQLnSIZkRyTORD3DLXOIPYbGlApaTCR5WbaR3oPiSsR9IqdhgMEZxCcarqGg7b_zzwTP98fDcALGZNGsJL1hIrl3EEXdPoYjsOJ5LMF1H57NZiteBDAsm1zfXgOgCtvCdt7PQFSCpM5GyE3und9VnEgjtcQ6HAZYdutqjI79vaTnjt2A1X38pbHcnfvSanzJoeU3szwtBiVlB3cfXbROvBC7Kz8KvbWJzImJcJiRT-KyI4kk3l8wAs2FUjSRco8AQ1nIX21QHlRI0vVr_vdOd_pTXOUU51g"
+      val jwt = Try(Jwt.validate(jwtString)).toEither.value
       val resp = Try(IronOxide.userCreate(jwt, "foo", new UserCreateOpts(true), null)).toEither
       resp.leftValue.getMessage should include("ServerError { message: \"\\'jwt ey")
     }
@@ -30,14 +42,10 @@ class UserTests extends TestSuite {
       user.getAccountId shouldBe dc.getAccountId
       user.getNeedsRotation shouldBe true
     }
-    "return error for invalid jwt" in {
-      val badResponseTry = Try(IronOxide.userVerify("foo", null))
-      badResponseTry.isFailure shouldBe true
-      badResponseTry.failed.get.getMessage should include("must be valid ascii and be formatted correctly")
-    }
     "return error for outdated jwt" in {
-      val jwt =
+      val jwtString =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTA3NzE4MjMsImlhdCI6MTU1MDc3MTcwMywia2lkIjo1NTEsInBpZCI6MTAxMiwic2lkIjoidGVzdC1zZWdtZW50Iiwic3ViIjoiYTAzYjhlNTYtMTVkMi00Y2Y3LTk0MWYtYzYwMWU1NzUxNjNiIn0.vlqt0da5ltA2dYEK9i_pfRxPd3K2uexnkbAbzmbjW65XNcWlBOIbcdmmQLnSIZkRyTORD3DLXOIPYbGlApaTCR5WbaR3oPiSsR9IqdhgMEZxCcarqGg7b_zzwTP98fDcALGZNGsJL1hIrl3EEXdPoYjsOJ5LMF1H57NZiteBDAsm1zfXgOgCtvCdt7PQFSCpM5GyE3und9VnEgjtcQ6HAZYdutqjI79vaTnjt2A1X38pbHcnfvSanzJoeU3szwtBiVlB3cfXbROvBC7Kz8KvbWJzImJcJiRT-KyI4kk3l8wAs2FUjSRco8AQ1nIX21QHlRI0vVr_vdOd_pTXOUU51g"
+      val jwt = Try(Jwt.validate(jwtString)).toEither.value
       val resp = Try(IronOxide.userVerify(jwt, null))
       resp.isFailure shouldBe true
       resp.failed.get.getMessage should include("was an invalid authorization token")

--- a/java/tests/src/test/scala/ironoxide/package.scala
+++ b/java/tests/src/test/scala/ironoxide/package.scala
@@ -1,7 +1,6 @@
 import com.ironcorelabs.sdk._
 import scala.util.Try
 import cats.scalatest.EitherValues
-import pdi.jwt.{Jwt, JwtClaim, JwtAlgorithm};
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 package object ironoxide extends EitherValues {
@@ -13,20 +12,21 @@ package object ironoxide extends EitherValues {
     new DeviceContext(dar)
   }
 
-  def generateValidJwt(accountId: String = java.util.UUID.randomUUID.toString, expiresInSec: Long = 120) = {
+  def generateValidJwt(accountId: String = java.util.UUID.randomUUID.toString, expiresInSec: Long = 120): Jwt = {
     java.security.Security.addProvider(new BouncyCastleProvider)
-
     val projectId = 431
     val segmentId = "ironoxide-java"
     val iakId = 597
     val key =
       "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgNdz7Kffzhn1PnAy1XI2YFUEnDC9TWbzctzIGvWqNv82hRANCAAQG3CAlUWHmBLRRkbwB4zSierd8BRbbyUlczZoNOiXKwbia9CZ9DJ/Dh72c8yFNNVr+hKdvV4Vhj2MQGbMF7Qo3"
     val currentTime = System.currentTimeMillis() / 1000
-    val claim = JwtClaim({ raw"""{"pid": $projectId,"sid": "$segmentId","kid": $iakId}""" })
+    val claim = pdi.jwt
+      .JwtClaim({ raw"""{"pid": $projectId,"sid": "$segmentId","kid": $iakId}""" })
       .about(accountId)
       .issuedAt(currentTime)
       .expiresAt(currentTime + expiresInSec)
-    Jwt.encode(claim, key, JwtAlgorithm.ES256)
+    val jwtString = pdi.jwt.Jwt.encode(claim, key, pdi.jwt.JwtAlgorithm.ES256)
+    Jwt.validate(jwtString)
   }
 
   val testUsersPassword = java.util.UUID.randomUUID.toString


### PR DESCRIPTION
Consuming latest ironoxide, need new Jwt types for `user_create`, `user_verify`, and `generate_new_device`. 

TODO:
- Depend on released ironoxide