### PR TITLE
Use gradle-nexus-staging-plugin.

### DIFF
--- a/.github/workflows/release2.yaml
+++ b/.github/workflows/release2.yaml
@@ -248,7 +248,7 @@ jobs:
       - name: Export PGP signing key
         run: gpg --export-secret-keys > /tmp/signing-key.gpg
       - name: Upload AAR to Maven Central
-        run: ./gradlew uploadArchives
+        run: ./gradlew uploadArchives closeAndReleaseRepository
         working-directory: android
 
   java:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,15 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2"
     }
 }
+
+apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
     repositories {

--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -37,7 +37,7 @@ uploadArchives {
             pom.artifactId = 'ironoxide-android'
             pom.version = VERSION_NAME
 
-            repository(url: "https://oss.sonatype.org/content/repositories/releases/") {
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
                 authentication(userName: NEXUS_USERNAME,
                                password: NEXUS_PASSWORD)
             }


### PR DESCRIPTION
This goes back to the previous strategy of publishing the Android release to Sonatype staging, then it adds the plugin to promote staging to release.