### PR TITLE
set-versions.sh: Handle unchanged files.

### DIFF
--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -5,7 +5,6 @@
 # If called with -n, don't actually change any files; just verify.
 
 set -e
-set -x
 
 # Parse args
 case "$1" in

--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -58,11 +58,13 @@ for FILE in ${EDITEDFILES} ; do
     git diff --cached "${FILE}"
     # Verify that we've changed either one or zero lines.
     git diff --cached --numstat "${FILE}" > "${TEMPFILE}"
-    # shellcheck disable=SC2034
-    read -r ADDED REMOVED FILENAME < "${TEMPFILE}"
-    if [ "${ADDED}" -gt 1 ] || [ "${REMOVED}" -gt 1 ] || [ "${ADDED}" -ne "${REMOVED}" ]; then
-        echo "Changes to ${FILE} must be exactly one line; aborting." >&2
-        exit 1
+    if [ -n "${TEMPFILE}" ] ; then
+        # shellcheck disable=SC2034
+        read -r ADDED REMOVED FILENAME < "${TEMPFILE}"
+        if [ "${ADDED}" -ne 1 ] || [ "${REMOVED}" -ne 1 ]; then
+            echo "Changes to ${FILE} must be exactly one line; aborting." >&2
+            exit 1
+        fi
     fi
     # If we're in verify mode, put the file back.
     if [ -n "${VERIFY}" ] ; then


### PR DESCRIPTION
Trying to gracefully handle the case where a file is unchanged after setting its version. I previously changed the logic so the output of diff count detect zero adds, zero removes. But in fact if there are no changes, diff won't output anything at all.