### PR TITLE
set-versions.sh: Fix bash test syntax.

### DIFF
--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -57,7 +57,7 @@ for FILE in ${EDITEDFILES} ; do
     git diff --cached "${FILE}"
     # Verify that we've changed either one or zero lines.
     git diff --cached --numstat "${FILE}" > "${TEMPFILE}"
-    if [ -n "${TEMPFILE}" ] ; then
+    if [ -s "${TEMPFILE}" ] ; then
         # shellcheck disable=SC2034
         read -r ADDED REMOVED FILENAME < "${TEMPFILE}"
         if [ "${ADDED}" -ne 1 ] || [ "${REMOVED}" -ne 1 ]; then


### PR DESCRIPTION
(This time I actually found a way to test it.)

Was using the wrong bash test syntax: `-n` instead of `-s`.