### PR TITLE
set-versions.sh: Revert to more paranoia.

### DIFF
--- a/.github/set-versions.sh
+++ b/.github/set-versions.sh
@@ -55,15 +55,13 @@ for FILE in ${EDITEDFILES} ; do
     git add "${FILE}"
     # Show the user the diff of what's changed.
     git diff --cached "${FILE}"
-    # Verify that we've changed either one or zero lines.
+    # Verify that we've changed exactly one line.
     git diff --cached --numstat "${FILE}" > "${TEMPFILE}"
-    if [ -s "${TEMPFILE}" ] ; then
-        # shellcheck disable=SC2034
-        read -r ADDED REMOVED FILENAME < "${TEMPFILE}"
-        if [ "${ADDED}" -ne 1 ] || [ "${REMOVED}" -ne 1 ]; then
-            echo "Changes to ${FILE} must be exactly one line; aborting." >&2
-            exit 1
-        fi
+    # shellcheck disable=SC2034
+    read -r ADDED REMOVED FILENAME < "${TEMPFILE}"
+    if [ "${ADDED}" -ne 1 ] || [ "${REMOVED}" -ne 1 ] ; then
+        echo "Changes to ${FILE} must be exactly one line; aborting." >&2
+        exit 1
     fi
     # If we're in verify mode, put the file back.
     if [ -n "${VERIFY}" ] ; then

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,3 +5,8 @@
 1. CI will run on the PR. Then it can either be approved and merged, or closed.
 1. Merging the PR will cause `release2.yaml` to run, which builds and publishes the release.
 1. After publishing the release, it increments Java-related versions to the next `-SNAPSHOT` release.
+
+# Re-Release
+
+If you need to re-release something, look at the last step of `release1.yaml` or the `if:` statements in `release2.yaml`. Manually
+create a PR that matches what `release2.yaml` expects. Then merge the PR, and it'll take over.


### PR DESCRIPTION
The whole effort to reduce the paranoia of this script was to support a workflow where we re-release a release that went wrong. After consideration, it seems like this script should stay paranoid. If we want to re-release, we should manually create the PR that `release1.yaml` would make.