### PR TITLE
Disable minify to fix issue with classes.jar

### DIFF
--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -19,7 +19,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
Minify was (suspected to be) making the `classes.jar` empty for our releases. This made v0.13.2 of ironoxide-android unusable as it could not find our java classes. 