### PR TITLE
Delete CI artifacts after run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,11 @@ jobs:
         with:
           name: ${{ matrix.folder-name }}
           path: android/ironoxide-android/src/main/android_build.zip
+      - name: Delete artifact when done
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ matrix.folder-name }}
+          failOnError: false
 
   # As the currently available emulators cannot use arm64-v8a architecture, we are currently only testing x86/x86_64.
   # This can be added in when either of the following happens:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Download android build
         uses: actions/download-artifact@v1
         with:
-          name: ${{ matrix.arch }}
+          name: blah${{ matrix.arch }}
       - name: Unzip Android build
         run: unzip -o ${{ matrix.arch }}/android_build.zip -d android/ironoxide-android/src/main
       - name: Run tests
@@ -174,8 +174,6 @@ jobs:
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
-            a
-            b
             x86
             x86_64
             arm64-v8a

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,11 +155,6 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: ${{ matrix.arch }}
-      - name: Delete artifact after download
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: ${{ matrix.arch }}
-          failOnError: false
       - name: Unzip Android build
         run: unzip -o ${{ matrix.arch }}/android_build.zip -d android/ironoxide-android/src/main
       - name: Run tests
@@ -169,6 +164,22 @@ jobs:
           arch: ${{ matrix.arch }}
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedAndroidTest
+
+  android-delete-artifacts:
+    needs: android-test
+    if: always()
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            a
+            b
+            x86
+            x86_64
+            arm64-v8a
+          failOnError: false
 
   cpp-build:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: ${{ matrix.arch }}
-      - name: Delete artifact
+      - name: Delete artifact after download
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ matrix.arch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - delete-artifacts
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - delete-artifacts
   pull_request:
 
 jobs:
@@ -154,7 +153,7 @@ jobs:
       - name: Download android build
         uses: actions/download-artifact@v1
         with:
-          name: blah${{ matrix.arch }}
+          name: ${{ matrix.arch }}
       - name: Unzip Android build
         run: unzip -o ${{ matrix.arch }}/android_build.zip -d android/ironoxide-android/src/main
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,8 @@ jobs:
     strategy:
       matrix:
         arch: [i686-linux-android, x86_64-linux-android, aarch64-linux-android]
+        # These folder names will be used as the names of artifacts uploaded by this job.
+        # In order to delete these artifacts, the same names must go into the list in the `android-delete-artifacts` job.
         include:
           - arch: i686-linux-android
             folder-name: x86
@@ -129,6 +131,8 @@ jobs:
         run: |
           cd android/ironoxide-android/src/main
           zip -r android_build.zip *
+        # Uploads the src/main as an artifact with the provided folder name as its name.
+        # In order to delete this artifact, the same name must go into the list in the `android-delete-artifacts` job.
       - name: Upload src/main as artifact
         uses: actions/upload-artifact@v1
         with:
@@ -164,6 +168,9 @@ jobs:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedAndroidTest
 
+  # This job cleans up the artifacts uploaded in `android-build` as they are not needed outside of the workflow.
+  # It will run even if `android-test` fails, ensuring that the artifacts get deleted.
+  # If deletion fails, the workflow is still able to succeed, and the artifacts will automatically expire after 90 days.
   android-delete-artifacts:
     needs: android-test
     if: always()
@@ -172,6 +179,7 @@ jobs:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
+          # These are the names of the artifacts uploaded in `android-build` and should be kept in sync with them
           name: |
             x86
             x86_64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,11 +135,6 @@ jobs:
         with:
           name: ${{ matrix.folder-name }}
           path: android/ironoxide-android/src/main/android_build.zip
-      - name: Delete artifact when done
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: ${{ matrix.folder-name }}
-          failOnError: false
 
   # As the currently available emulators cannot use arm64-v8a architecture, we are currently only testing x86/x86_64.
   # This can be added in when either of the following happens:
@@ -160,6 +155,11 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: ${{ matrix.arch }}
+      - name: Delete artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ matrix.arch }}
+          failOnError: false
       - name: Unzip Android build
         run: unzip -o ${{ matrix.arch }}/android_build.zip -d android/ironoxide-android/src/main
       - name: Run tests

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -131,7 +131,7 @@ jobs:
         with:
           name: release-macos-10.15
           failOnError: false
-      - name: Sign artifact for release-iOS
+      - name: Sign iOS artifact
         run: |
           gpg --batch --detach-sign -a release/release-iOS/ironoxide-homebrew.tar.gz
           gpg --batch --verify release/release-iOS/ironoxide-homebrew.tar.gz.asc release/release-iOS/ironoxide-homebrew.tar.gz

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -60,6 +60,11 @@ jobs:
         with:
           name: release-ubuntu-18.04
           path: release/ubuntu-18.04
+      - name: Delete artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: release-ubuntu-18.04
+          failOnError: false
       - name: Sign artifact for ubuntu-18.04
         run: |
           gpg --batch --detach-sign -a release/ubuntu-18.04/libironoxide_java.so
@@ -88,6 +93,11 @@ jobs:
         with:
           name: release-macos-10.15
           path: release/macos-10.15
+      - name: Delete artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: release-macos-10.15
+          failOnError: false
       - name: Sign artifact for macos-10.15
         run: |
           gpg --batch --detach-sign -a release/macos-10.15/libironoxide_java.dylib
@@ -144,6 +154,11 @@ jobs:
         with:
           name: release-iOS
           path: release/release-iOS
+      - name: Delete artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: release-macos-10.15
+          failOnError: false
       - name: Sign artifact for release-iOS
         run: |
           gpg --batch --detach-sign -a release/release-iOS/ironoxide-homebrew.tar.gz


### PR DESCRIPTION
This is the best way I've found to delete artifacts uploaded by CI.

In most repos, it will be simpler to put the `geekyeggo/delete-artifact@v1` call immediately after the step that downloads the artifact. However, that doesn't work in this workflow because there are 2 matrix builds using each artifact, so the first one to download would then delete the artifact before the second one could download.

Doing it as a separate job makes sure that all `android-test` matrix jobs have finished before it starts, and the `if: always()` makes it run the job even if `android-test` fails.

If for some reason it's unable to delete some of the artifacts, the workflow will still succeed (and emit a warning), and we'll just wait the 90 days for the artifact to expire (or we can manually delete if necessary).