### PR TITLE
Ironoxide-swig release fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,12 @@ jobs:
         with:
           name: ${{ matrix.folder-name }}
           path: android/ironoxide-android/src/main/android_build.zip
+      # We aren't doing anything with this build, but it's the best place to check that
+      # the build will be successful if we go on to release. In particular, it will catch if the
+      # NDK version we have specified is different than the one installed on the machine.
+      - name: Run gradle build
+        run: ./gradlew build
+        working-directory: android
 
   # As the currently available emulators cannot use arm64-v8a architecture, we are currently only testing x86/x86_64.
   # This can be added in when either of the following happens:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,17 +164,20 @@ jobs:
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedAndroidTest
 
-  # This tests the scripts and tasks that are needed to release ironoxide-android.
+  # This tests that gradle can build ironoxide-android so we can catch issues before release.
   android-release-test:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install cross
         run: cargo install cross
-      # Because this script runs `./gradlew build`, this will test that we're able to build the .aar files required for release.
-      # In particular, it will catch if the NDK version we have specified is different than the one installed on the machine.
       - name: Run build script
-        run: ./build-aar.sh
+        run: ./build.sh
+        working-directory: android
+      # This will test that we're able to build the .aar file required for release.
+      # In particular, it will catch if the NDK version we have specified is different than the one installed on the machine.
+      - name: Run gradle build
+        run: ./gradlew build
         working-directory: android
 
   cpp-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,12 +134,6 @@ jobs:
         with:
           name: ${{ matrix.folder-name }}
           path: android/ironoxide-android/src/main/android_build.zip
-      # We aren't doing anything with this build, but it's the best place to check that
-      # the build will be successful if we go on to release. In particular, it will catch if the
-      # NDK version we have specified is different than the one installed on the machine.
-      - name: Run gradle build
-        run: ./gradlew build
-        working-directory: android
 
   # As the currently available emulators cannot use arm64-v8a architecture, we are currently only testing x86/x86_64.
   # This can be added in when either of the following happens:
@@ -169,6 +163,19 @@ jobs:
           arch: ${{ matrix.arch }}
           api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedAndroidTest
+
+  # This tests the scripts and tasks that are needed to release ironoxide-android.
+  android-release-test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cross
+        run: cargo install cross
+      # Because this script runs `./gradlew build`, this will test that we're able to build the .aar files required for release.
+      # In particular, it will catch if the NDK version we have specified is different than the one installed on the machine.
+      - name: Run build script
+        run: ./build-aar.sh
+        working-directory: android
 
   cpp-build:
     strategy:

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -4,13 +4,15 @@ name: Build Android release
 # to Maven Central.
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches: trigger-me
+  # pull_request:
+  #   types:
+  #     - closed
 
 jobs:
   android:
-    if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
+    # if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -4,15 +4,13 @@ name: Build Android release
 # to Maven Central.
 
 on:
-  push:
-    branches: trigger-me
-  # pull_request:
-  #   types:
-  #     - closed
+  pull_request:
+    types:
+      - closed
 
 jobs:
   android:
-    # if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
+    if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -13,8 +13,8 @@ jobs:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-18.04
     needs:
-      - build
-      - cpp
+      - build-java
+      - build-cpp
     steps:
       - uses: actions/checkout@v2
         with:
@@ -55,16 +55,16 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           release_name: Version ${{ steps.version.outputs.tag }}
 
-      - name: Download release artifacts from ubuntu-18.04
+      - name: Download java release artifacts from ubuntu-18.04
         uses: actions/download-artifact@v1
         with:
           name: release-ubuntu-18.04
           path: release/ubuntu-18.04
-      - name: Sign artifact for ubuntu-18.04
+      - name: Sign java artifact for ubuntu-18.04
         run: |
           gpg --batch --detach-sign -a release/ubuntu-18.04/libironoxide_java.so
           gpg --batch --verify release/ubuntu-18.04/libironoxide_java.so.asc release/ubuntu-18.04/libironoxide_java.so
-      - name: Upload lib for ubuntu-18.04
+      - name: Upload java lib for ubuntu-18.04
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
           asset_path: release/ubuntu-18.04/libironoxide_java.so
           asset_name: libironoxide_java.so
           asset_content_type: application/data
-      - name: Upload signature for ubuntu-18.04
+      - name: Upload java signature for ubuntu-18.04
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,16 +83,16 @@ jobs:
           asset_name: libironoxide_java.so.asc
           asset_content_type: application/pgp-signature
 
-      - name: Download release artifacts from macos-10.15
+      - name: Download java release artifacts from macos-10.15
         uses: actions/download-artifact@v1
         with:
           name: release-macos-10.15
           path: release/macos-10.15
-      - name: Sign artifact for macos-10.15
+      - name: Sign java artifact for macos-10.15
         run: |
           gpg --batch --detach-sign -a release/macos-10.15/libironoxide_java.dylib
           gpg --batch --verify release/macos-10.15/libironoxide_java.dylib.asc release/macos-10.15/libironoxide_java.dylib
-      - name: Upload lib for macos-10.15
+      - name: Upload java lib for macos-10.15
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
           asset_path: release/macos-10.15/libironoxide_java.dylib
           asset_name: libironoxide_java.dylib
           asset_content_type: application/data
-      - name: Upload signature for macos-10.15
+      - name: Upload java signature for macos-10.15
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,40 +111,12 @@ jobs:
           asset_name: libironoxide_java.dylib.asc
           asset_content_type: application/pgp-signature
 
-      - name: Download release artifacts from android-release
-        uses: actions/download-artifact@v1
-        with:
-          name: android-release
-          path: release/android-release
-      - name: Sign artifact for android-release
-        run: |
-          gpg --batch --detach-sign -a release/android-release/ironoxide-android-release.aar
-          gpg --batch --verify release/android-release/ironoxide-android-release.aar.asc release/android-release/ironoxide-android-release.aar
-      - name: Upload aar for android-release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/android-release/ironoxide-android-release.aar
-          asset_name: ironoxide-android-release.aar
-          asset_content_type: application/data
-      - name: Upload signature for android-release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: release/android-release/ironoxide-android-release.aar.asc
-          asset_name: ironoxide-android-release.aar.asc
-          asset_content_type: application/pgp-signature
-
-      - name: Download release artifacts from release-iOS
+      - name: Download iOS release artifacts from build-cpp
         uses: actions/download-artifact@v1
         with:
           name: release-iOS
           path: release/release-iOS
-      - name: Sign artifact for release-iOS
+      - name: Sign iOS artifact
         run: |
           gpg --batch --detach-sign -a release/release-iOS/ironoxide-homebrew.tar.gz
           gpg --batch --verify release/release-iOS/ironoxide-homebrew.tar.gz.asc release/release-iOS/ironoxide-homebrew.tar.gz
@@ -174,7 +146,7 @@ jobs:
       - run: git commit -m "Set next -SNAPSHOT version for Java."
       - run: git push
 
-  build:
+  build-java:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     strategy:
       matrix:
@@ -209,7 +181,7 @@ jobs:
           name: release-macos-10.15
           path: target/release/libironoxide_java.dylib
 
-  cpp:
+  build-cpp:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: macos-10.15
     steps:

--- a/android/examples/Example_Application/app/build.gradle
+++ b/android/examples/Example_Application/app/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
+    // This is the same NDK version as used in ironoxide-android.
+    // We should keep these in sync for best compatibility.
     ndkVersion "21.3.6528147"
 
     defaultConfig {

--- a/android/examples/Example_Application/app/build.gradle
+++ b/android/examples/Example_Application/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
+    ndkVersion "21.3.6528147"
 
     defaultConfig {
         applicationId "com.ironcorelabs.example_application"
@@ -14,7 +15,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.ironcorelabs:ironoxide-android:0.13.1@aar'
+    implementation 'com.ironcorelabs:ironoxide-android:0.14.2@aar'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 24 10:49:48 MDT 2020
+#Mon Jul 06 16:16:38 MDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'signing'
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
+    // Locked NDK version for consistent builds. We use the same version in the Example App
+    // and they should remain in sync for best compatibility.
     ndkVersion "21.3.6528147"
 
     defaultConfig {

--- a/android/ironoxide-android/build.gradle
+++ b/android/ironoxide-android/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'signing'
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
+    ndkVersion "21.3.6528147"
 
     defaultConfig {
         // sdk version 24 required to support Java's Optional type

--- a/android/ironoxide-android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/ironoxide-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 20 15:26:09 MDT 2020
+#Mon Jul 06 16:16:07 MDT 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip


### PR DESCRIPTION
There were 2 things wrong last time we tried to release:
1. We decided to stop uploading the `aar`s to GitHub Releases. We removed that build step from `release-github.yaml`, but forgot to remove the steps that try to upload that build.
2. When we run `./gradlew build`, one of the steps is `stripDebugDebugSymbols` which uses the Android NDK to remove unnecessary things from our `.so`s. Apparently this isn't in a great state with the current Android Gradle plugin. If you have no NDK installed, it's fine and doesn't strip. If you have an NDK installed that _isn't_ the one it wanted, it fails. Our GHA build failed because it had an NDK installed that was newer than the default (and I have no idea where the old default came from). So I locked our NDK version to the one that it had installed for now. Hopefully we'll learn in the future what controls what NDK version GHA has installed. I added a job to CI that should catch this issue before we go to release. We do want to keep stripping enabled because it brings our `.aar` sizes down ~20% (and I did check that it wasn't removing anything from our `classes.jar` and was usable from the example app).