### PR TITLE
Attempt release CI changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Validate version files
         # Make sure we still know how to edit the version files. (But discard the changes.)
         run: .github/set-versions.sh -n 0.0.1
@@ -29,7 +29,7 @@ jobs:
     env:
       COURSIER_CACHE: /tmp/.cache/coursier/v1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore rust cache
         uses: actions/cache@v2
         with:
@@ -94,7 +94,7 @@ jobs:
             folder-name: arm64-v8a
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore rust cache
         uses: actions/cache@v2
         with:
@@ -141,7 +141,7 @@ jobs:
         arch: [x86, x86_64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download android build
         uses: actions/download-artifact@v1
         with:
@@ -178,7 +178,7 @@ jobs:
   android-release-test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install cross
         run: cargo install cross
       - name: Run build script
@@ -197,7 +197,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore rust cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -16,13 +16,13 @@ jobs:
       - build-java
       - build-cpp
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # base_ref will typically be main. We'll need to commit a change to that branch and push it.
           ref: ${{ github.base_ref }}
-          # If we use the default GITHUB_TOKEN then CI won't run after we push our changes. This DEPLOYMENT_TOKEN is a personal
+          # If we use the default GITHUB_TOKEN then CI won't run after we push our changes. This WORKFLOW_PAT is a personal
           # access token with "repo" permissions.
-          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
       - name: Decrypt PGP key
         uses: IronCoreLabs/ironhide-actions/decrypt@v1
         with:
@@ -126,7 +126,7 @@ jobs:
         os: [ubuntu-18.04, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: 11
@@ -158,7 +158,7 @@ jobs:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -189,11 +189,11 @@ jobs:
     needs:
       - release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          # If we use the default GITHUB_TOKEN, it won't run our CI job once we create a PR. The DEPLOYMENT_TOKEN is a personal
+          # If we use the default GITHUB_TOKEN, it won't run our CI job once we create a PR. The WORKFLOW_PAT is a personal
           # access token with "repo" permissions.
-          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
           repository: IronCoreLabs/homebrew-ironcore
       - name: Configure git
         run: |

--- a/.github/workflows/release-java.yaml
+++ b/.github/workflows/release-java.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Decrypt PGP key
         uses: IronCoreLabs/ironhide-actions/decrypt@v1
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -12,7 +12,7 @@ jobs:
   security-audit:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/start-release.yaml
+++ b/.github/workflows/start-release.yaml
@@ -16,11 +16,11 @@ jobs:
     if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-')
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          # If we use the default GITHUB_TOKEN, it won't run our CI job once we create a PR. The DEPLOYMENT_TOKEN is a personal
+          # If we use the default GITHUB_TOKEN, it won't run our CI job once we create a PR. The WORKFLOW_PAT is a personal
           # access token with "repo" permissions.
-          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
       - name: Configure git
         run: |
           git config --local user.email ops@ironcorelabs.com


### PR DESCRIPTION
The release workflow failed at the checkout step. I assume this means that there's something wrong with the token, but you can't view secret tokens. This PR attempts switching it to our organization WORKFLOW_PAT instead.