### PR TITLE
Use short key IDs for PGP.

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -208,7 +208,7 @@ jobs:
           wget -q ${ARTIFACT}
           SHA256=$(sha256sum -b ironoxide-homebrew.tar.gz | awk '{print $1}')
           echo "::set-output name=tag::${NAME}"
-          echo "::set-output name=pr_branch::ironoxide-swig-bindings-${NAME}
+          echo "::set-output name=pr_branch::ironoxide-swig-bindings-${NAME}"
           echo "::set-output name=artifact::${ARTIFACT}"
           echo "::set-output name=sha256::${SHA256}"
       - name: Edit files for pending release

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,6 +5,7 @@ android.enableJetifier=true
 VERSION_NAME=0.14.7-SNAPSHOT
 
 # GPG info for signing artifacts before uploading them.
-signing.keyId=1F6210B39FA43559
+# This key is the last 4 bytes of the key ID of the signing subkey.
+signing.keyId=9FA43559
 signing.secretKeyRingFile=/tmp/signing-key.gpg
 signing.password=

--- a/java/tests/publish.sbt
+++ b/java/tests/publish.sbt
@@ -12,7 +12,8 @@ pomIncludeRepository := { _ => false }
 
 useGpg := true
 
-usePgpKeyHex("1F6210B39FA43559")
+// This key is the last 4 bytes of the key ID of the signing subkey.
+usePgpKeyHex("9FA43559")
 
 pomExtra := (
     <scm>


### PR DESCRIPTION
https://security.stackexchange.com/questions/84280/short-openpgp-key-ids-are-insecure-how-to-configure-gnupg-to-use-long-key-ids-i#84281 says that we should use the last few bytes of the key.

I also fixed a syntax error which makes me wonder if `homebrew-ironcore` has ever successfully run.