### PR TITLE
Change token used for homebrew-ironcore workflow

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -222,7 +222,7 @@ jobs:
       - name: Create PR
         run: |
           curl --silent --show-error --fail -X POST \
-            -H "Authorization: token ${{ github.token }}" \
+            -H "Authorization: token ${{ secrets.WORKFLOW_PAT }}" \
             -H "Content-Type: application/json" \
             --data '{"title": "Use new ironoxide-swig-bindings ${{ steps.vars.outputs.tag }}",
               "head": "${{ steps.vars.outputs.pr_branch }}",


### PR DESCRIPTION
This token was already used earlier in the workflow to checkout `IronCoreLabs/homebrew-ironcore`, so hopefully we can use it to create the pull request as well. However, this won't get tested until our next release.